### PR TITLE
Minor edits to javadocs, and edit to pom.xml to use a SNAPSHOT version number for local builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
  
     <groupId>org.cicirello</groupId>
 	<artifactId>interactive-bin-packing</artifactId>
-	<version>3.0.0</version>
+	<version>3-SNAPSHOT</version>
 	<packaging>jar</packaging>
   
 	<name>Interactive Bin Packing Application</name>

--- a/src/main/java/org/cicirello/ibp/BottomPanel.java
+++ b/src/main/java/org/cicirello/ibp/BottomPanel.java
@@ -44,10 +44,19 @@ import java.util.ArrayList;
  */
 public class BottomPanel extends JPanel {
 	
+	/** Application. */
 	private InteractiveBinPacking f;
+	
+	/** Maintains application state. */
 	private ApplicationState state;
+	
+	/** Combo box of destinations. */
 	private JComboBox<Bin> destinations;
+	
+	/** Combo box of items. */
 	private JComboBox<Item> itemList;
+	
+	/** Called when item moved. */
 	private CallBack onMove;
 	
 	/**

--- a/src/main/java/org/cicirello/ibp/CenterPanel.java
+++ b/src/main/java/org/cicirello/ibp/CenterPanel.java
@@ -38,7 +38,10 @@ import java.util.ArrayList;
  */
 public class CenterPanel extends JPanel {
 	
+	/** Contents of the bins. */
 	private ArrayList<JTextField> binContents;
+	
+	/** Maintains application state. */
 	private ApplicationState state;
 	
 	/**

--- a/src/main/java/org/cicirello/ibp/InfoDialog.java
+++ b/src/main/java/org/cicirello/ibp/InfoDialog.java
@@ -127,6 +127,7 @@ public class InfoDialog extends JDialog {
 		activationCount++;
 	}
 	
+	/** Simple count of number of times the dialog box was activated. */
 	private int activationCount;
 	
 	private static boolean visibility = true;

--- a/src/main/java/org/cicirello/ibp/MenuBar.java
+++ b/src/main/java/org/cicirello/ibp/MenuBar.java
@@ -49,12 +49,25 @@ import java.io.FileReader;
  */
 public class MenuBar extends JMenuBar {
 	
+	/** Application. */
 	private InteractiveBinPacking f;
+	
+	/** Maintains application state. */
 	private ApplicationState state;
+	
+	/** Menu item for sorting. */
 	private JMenuItem sortItem;
+	
+	/** Menu item for sorting in increasing order. */
 	private JMenuItem sortItemInc;
+	
+	/** The tutorial dialog. */
 	private Tutorial tutorial;
+	
+	/** The help dialog. */
 	private Help help;
+	
+	/** The file chooser. */
 	private JFileChooser chooser;
 		
 	/**

--- a/src/main/java/org/cicirello/ibp/SessionLog.java
+++ b/src/main/java/org/cicirello/ibp/SessionLog.java
@@ -50,9 +50,14 @@ import java.util.regex.Pattern;
 public final class SessionLog implements Serializable {
 	 
 	private static final long serialVersionUID = 1L;
-	 
+	
+	/** List of log records. */
 	private final RecordList records;
+	
+	/** Counts of successful moves in each mode. */
 	private final int[] successfulMoves;
+	
+	/** Counts of failed mvoes in each mode. */
 	private final int[] failedMoves;	
 	
 	private transient int currentMode;

--- a/src/main/java/org/cicirello/ibp/TopPanel.java
+++ b/src/main/java/org/cicirello/ibp/TopPanel.java
@@ -37,7 +37,10 @@ import java.awt.Color;
  */
 public class TopPanel extends JPanel {
 	
+	/** Items not yet in bins. */
 	private JTextArea floorItems;
+	
+	/** Maintains application state. */
 	private ApplicationState state;
 	
 	/**

--- a/src/main/java/org/cicirello/ibp/UI.java
+++ b/src/main/java/org/cicirello/ibp/UI.java
@@ -37,11 +37,19 @@ import java.awt.Color;
  */
 public class UI extends JPanel {
 	
+	/** The top panel. */
 	private TopPanel top;
+	
+	/** The bottom panel. */
 	private BottomPanel bottom;
+	
+	/** The panel to the left. */
 	private WestPanel west;
+	
+	/** The center panel. */
 	private CenterPanel center;
 	
+	/** Maintains application state. */
 	private ApplicationState state;
 	
 	/**

--- a/src/main/java/org/cicirello/ibp/WestPanel.java
+++ b/src/main/java/org/cicirello/ibp/WestPanel.java
@@ -39,7 +39,10 @@ import java.util.ArrayList;
  */
 public class WestPanel extends JPanel {
 	
+	/** List of how much of each bin is used. */
 	private ArrayList<JLabel> usedLabels;
+	
+	/** Maintains application state. */
 	private ApplicationState state;
 	
 	/**


### PR DESCRIPTION
## Summary

Our CI/CD workflows injects the real version number at the time artifacts are published to Maven Central, etc. The pom.xml had a specific prior version number hardcoded, which may cause confusion if someone builds locally (e.g., may mistakenly think they have an older specific version). Changed the version attribute in the pom.xml to 3-SNAPSHOT so locally built artifacts that are built directly from the current state of the default branch will be clearly identified as a SNAPSHOT.

Also minor edits to javadoc comments.
