### PR TITLE
Replaced use of deprecated set-output in deployment workflow

### DIFF
--- a/.github/workflows/manual-docker.yml
+++ b/.github/workflows/manual-docker.yml
@@ -22,7 +22,7 @@ jobs:
           MINOR=${VERSION%.*}
           MAJOR=${VERSION%%.*}
           TAGS="${VERSION},${MINOR},${MAJOR}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Get the release version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
 
     - name: Set up JDK 11 for deploy to OSSRH
       uses: actions/setup-java@v3


### PR DESCRIPTION
## Summary
Replaced use of deprecated set-output in deployment workflow

## Closing Issues
Closes #94 
