### PR TITLE
Fixed download instructions in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Refactored to eliminate dispersed coupling in About constructor, identified by RefactorFirst.
 * Refactored to eliminate dispersed coupling in SessionLog.parseActions, identified by RefactorFirst.
 * Refactored to eliminate dispersed coupling in SessionLogFormatter.formatCompletions, identified by RefactorFirst.
+* Instructions in the README for downloading from Maven Central using curl
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,13 @@ jar file from a variety of sources. The filename of the jar is of the form
 To install, simply download the `jar` of the latest release by doing any of the
 following:
 * From the command line via 
-  [Maven Central](https://central.sonatype.com/artifact/org.cicirello/interactive-bin-packing/):  
+  [Maven Central](https://central.sonatype.com/artifact/org.cicirello/interactive-bin-packing/), run the following command but replace the two instances of `X.Y.Z` with the version number that you want to download:  
   ```Shell
-  curl -O -J -L  "https://repository.sonatype.org/service/local/artifact/maven/content?r=central-proxy&g=org.cicirello&a=interactive-bin-packing&e=jar&v=LATEST"
+  curl -O -J -L "https://repo1.maven.org/maven2/org/cicirello/interactive-bin-packing/X.Y.Z/interactive-bin-packing-X.Y.Z.jar"
+  ```
+  For example, to download version `4.0.0`, run:
+  ```Shell
+  curl -O -J -L "https://repo1.maven.org/maven2/org/cicirello/interactive-bin-packing/4.0.0/interactive-bin-packing-4.0.0.jar"
   ```
 * From 
   [Maven Central](https://central.sonatype.com/artifact/org.cicirello/interactive-bin-packing/) 


### PR DESCRIPTION
## Summary
Fixed the instructions in the README for downloading from Maven Central using curl.

## Closing Issues
Closes #148 

## Pull Request Requirements 
If you are unable to check everything in this list, your pull request will be closed:
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My pull request has a corresponding Issue and I linked to it above in the [Closing Issues](#closing-issues) section.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
